### PR TITLE
Remove `plugin.name`

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ const precheck = () => {
     return true;
 };
 module.exports = {
-    name: 'netlify-plugin-pushover',
     async onSuccess() {
         if (precheck()) {
             console.log('Sending build success message via PushOver');


### PR DESCRIPTION
The `name` property of plugins has been removed from Netlify since it is redundant with the `name` property of `manifest.yml`.