### PR TITLE
Ensure confidential information is not printed in public logs

### DIFF
--- a/pushover-helper.js
+++ b/pushover-helper.js
@@ -18,8 +18,17 @@ const sendPushOverNotification = async payload => {
         ...payload,
     };
 
-    const res = await axios.default.post(PUSHOVER_MSG_URL, data);
-    return res.data;
+    try {
+        const res = await axios.default.post(PUSHOVER_MSG_URL, data);
+        return res.data;
+    } catch (error) {
+        // Ensure confidential information are not printed in public build logs
+        if (error && error.config && error.config.data) {
+          delete error.config.data
+        }
+
+        throw error
+    }
 };
 
 module.exports = sendPushOverNotification;


### PR DESCRIPTION
Static properties of errors thrown from plugins are printed in the build logs. If the Site is public, those should not print any potentially confidential information such as access tokens.

This PR ensures this does not happen. When Axios errors, the error instance includes a `config.data` static property which might contain such information.