### PR TITLE
fix: switch to failPlugin instead of failBuild

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
             try {
                 await sendPushOverNotification({ message });
             } catch (error) {
-                return utils.build.failBuild(
+                return utils.build.failPlugin(
                     'Failed to send PushOver message',
                     { error }
                 );
@@ -45,7 +45,7 @@ module.exports = {
                     sound: 'siren',
                 });
             } catch (error) {
-                return utils.build.failBuild(
+                return utils.build.failPlugin(
                     'Failed to send PushOver message',
                     { error }
                 );


### PR DESCRIPTION
Hi @AshikNesin, thank you for creating this plugin 🎉 

We're making a change to how `onSuccess` works.

**Current:**  `onSuccess` occurs after the build command is complete, but before any files are uploaded.
**Upcoming:** `onSuccess`  occurs after the site is deployed, live, and published to production (if applicable).

As a result `onSuccess` can no longer be used to fail the build, hence the change to `failPlugin`.

Since this plugin triggers a push notification it would make sense to use `failPlugin` and not fail the build on failure to send a notification (if I'm not mistaken).